### PR TITLE
Improve tests and types

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -431,7 +431,6 @@ parameter_types! {
     pub const ChannelOwnershipPaymentEscrowId: [u8; 8] = *b"chescrow";
     pub const VideosMigrationsEachBlock: u64 = 20;
     pub const ChannelsMigrationsEachBlock: u64 = 10;
-
 }
 
 impl content::Trait for Runtime {

--- a/types/augment/all/defs.json
+++ b/types/augment/all/defs.json
@@ -903,5 +903,13 @@
     },
     "MaxNumber": "u32",
     "IsCensored": "bool",
+    "VideoMigrationConfig": {
+        "current_id": "VideoId",
+        "final_id": "VideoId"
+    },
+    "ChannelMigrationConfig": {
+        "current_id": "ChannelId",
+        "final_id": "ChannelId"
+    },
     "AccountInfo": "AccountInfoWithRefCount"
 }

--- a/types/augment/all/types.ts
+++ b/types/augment/all/types.ts
@@ -245,6 +245,12 @@ export interface ChannelCurationStatus extends Null {}
 /** @name ChannelId */
 export interface ChannelId extends u64 {}
 
+/** @name ChannelMigrationConfig */
+export interface ChannelMigrationConfig extends Struct {
+  readonly current_id: ChannelId;
+  readonly final_id: ChannelId;
+}
+
 /** @name ChannelOwner */
 export interface ChannelOwner extends Enum {
   readonly isMember: boolean;
@@ -1380,6 +1386,12 @@ export interface VideoCreationParameters extends Struct {
 
 /** @name VideoId */
 export interface VideoId extends u64 {}
+
+/** @name VideoMigrationConfig */
+export interface VideoMigrationConfig extends Struct {
+  readonly current_id: VideoId;
+  readonly final_id: VideoId;
+}
 
 /** @name VideoUpdateParameters */
 export interface VideoUpdateParameters extends Struct {

--- a/types/src/content/index.ts
+++ b/types/src/content/index.ts
@@ -177,6 +177,7 @@ export class ChannelMigrationConfig extends JoyStructDecorated({
   current_id: ChannelId,
   final_id: ChannelId,
 }) {}
+
 export const contentTypes = {
   CuratorId,
   CuratorGroupId,

--- a/types/src/content/index.ts
+++ b/types/src/content/index.ts
@@ -170,12 +170,12 @@ export class PersonActor extends JoyEnum({
 }) {}
 
 export class VideoMigrationConfig extends JoyStructDecorated({
-    current_id: VideoId,
-    final_id: VideoId,    
+  current_id: VideoId,
+  final_id: VideoId,
 }) {}
 export class ChannelMigrationConfig extends JoyStructDecorated({
-    current_id: ChannelId,
-    final_id: ChannelId,    
+  current_id: ChannelId,
+  final_id: ChannelId,
 }) {}
 export const contentTypes = {
   CuratorId,
@@ -219,6 +219,8 @@ export const contentTypes = {
   EpisodeParemters,
   MaxNumber,
   IsCensored,
+  VideoMigrationConfig,
+  ChannelMigrationConfig,
 }
 
 export default contentTypes


### PR DESCRIPTION
The tests still had some assumptions on the number of channels and videos that are processed per block.

The types definition was incomplete. After being added they must also be exported. In addition `yarn generate:all` should be called to update the augment types.