### PR TITLE
allow more time for playground to deploy before timeout

### DIFF
--- a/devops/ansible/deploy-playground-playbook.yml
+++ b/devops/ansible/deploy-playground-playbook.yml
@@ -69,7 +69,7 @@
         TREASURY_ACCOUNT_URI: '{{ treasury_suri }}'
         INITIAL_BALANCES: '{{ initial_balances }}'
         SKIP_NODE: 'true'
-      async: 1800
+      async: 3600
       poll: 0
       register: start_services_result
 
@@ -79,7 +79,7 @@
       register: job_result
       until: job_result.finished
       # Max number of times to check for status
-      retries: 18
+      retries: 36
       # Check for the status every 100s
       delay: 100
 


### PR DESCRIPTION
Deployment is timing out in the ansible job, as it takes longer now to elect council and hire leads via proposals.
Increased the timeout from 30min to 60min which seems to be enough.

Failed job
https://github.com/Joystream/joystream/actions/runs/4134320191/jobs/7145316623#step:7:10128
<img width="1109" alt="Screenshot 2023-02-09 at 11 34 40 PM" src="https://user-images.githubusercontent.com/1621012/217944323-0e9e217c-7e67-4f7b-81ca-b525cccee78b.png">

With adjusted timeout we can see the job was taking about 55min
<img width="1016" alt="Screenshot 2023-02-09 at 11 35 12 PM" src="https://user-images.githubusercontent.com/1621012/217944430-f1335aab-6140-48a4-b4f4-b0fe1f7df88d.png">

